### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -109,7 +109,7 @@ impl fmt::Display for Literal {
                 if n.fract() == 0.0 {
                     format!("{}.0", n)
                 } else {
-                    format!("{:.}", n)
+                    format!("{}", n)
                 }
             }
             Literal::Nil => "nil".to_string(),


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.